### PR TITLE
Adding Upsert feature

### DIFF
--- a/documentdb.go
+++ b/documentdb.go
@@ -10,11 +10,11 @@ package documentdb
 import "reflect"
 
 type Config struct {
-	MasterKey	string
+	MasterKey string
 }
 
 type DocumentDB struct {
-	client	Clienter
+	client Clienter
 }
 
 // Create DocumentDBClient
@@ -97,8 +97,8 @@ func (c *DocumentDB) ReadDocuments(coll string, docs interface{}) (err error) {
 // Read all databases that satisfy a query
 func (c *DocumentDB) QueryDatabases(query string) (dbs []Database, err error) {
 	data := struct {
-		Databases	[]Database	`json:"Databases,omitempty"`
-		Count		int		`json:"_count,omitempty"`
+		Databases []Database `json:"Databases,omitempty"`
+		Count     int        `json:"_count,omitempty"`
 	}{}
 	if len(query) > 0 {
 		err = c.client.Query("dbs", query, &data)
@@ -114,13 +114,13 @@ func (c *DocumentDB) QueryDatabases(query string) (dbs []Database, err error) {
 // Read all db-collection that satisfy a query
 func (c *DocumentDB) QueryCollections(db, query string) (colls []Collection, err error) {
 	data := struct {
-		Collections	[]Collection	`json:"DocumentCollections,omitempty"`
-		Count		int		`json:"_count,omitempty"`
+		Collections []Collection `json:"DocumentCollections,omitempty"`
+		Count       int          `json:"_count,omitempty"`
 	}{}
 	if len(query) > 0 {
-		err = c.client.Query(db + "colls/", query, &data)
+		err = c.client.Query(db+"colls/", query, &data)
 	} else {
-		err = c.client.Read(db + "colls/", &data)
+		err = c.client.Read(db+"colls/", &data)
 	}
 	if colls = data.Collections; err != nil {
 		colls = nil
@@ -131,13 +131,13 @@ func (c *DocumentDB) QueryCollections(db, query string) (colls []Collection, err
 // Read all collection `sprocs` that satisfy a query
 func (c *DocumentDB) QueryStoredProcedures(coll, query string) (sprocs []Sproc, err error) {
 	data := struct {
-		Sprocs	[]Sproc	`json:"StoredProcedures,omitempty"`
-		Count	int	`json:"_count,omitempty"`
+		Sprocs []Sproc `json:"StoredProcedures,omitempty"`
+		Count  int     `json:"_count,omitempty"`
 	}{}
 	if len(query) > 0 {
-		err = c.client.Query(coll + "sprocs/", query, &data)
+		err = c.client.Query(coll+"sprocs/", query, &data)
 	} else {
-		err = c.client.Read(coll + "sprocs/", &data)
+		err = c.client.Read(coll+"sprocs/", &data)
 	}
 	if sprocs = data.Sprocs; err != nil {
 		sprocs = nil
@@ -148,13 +148,13 @@ func (c *DocumentDB) QueryStoredProcedures(coll, query string) (sprocs []Sproc, 
 // Read all collection `udfs` that satisfy a query
 func (c *DocumentDB) QueryUserDefinedFunctions(coll, query string) (udfs []UDF, err error) {
 	data := struct {
-		Udfs	[]UDF	`json:"UserDefinedFunctions,omitempty"`
-		Count	int	`json:"_count,omitempty"`
+		Udfs  []UDF `json:"UserDefinedFunctions,omitempty"`
+		Count int   `json:"_count,omitempty"`
 	}{}
 	if len(query) > 0 {
-		err = c.client.Query(coll + "udfs/", query, &data)
+		err = c.client.Query(coll+"udfs/", query, &data)
 	} else {
-		err = c.client.Read(coll + "udfs/", &data)
+		err = c.client.Read(coll+"udfs/", &data)
 	}
 	if udfs = data.Udfs; err != nil {
 		udfs = nil
@@ -165,13 +165,13 @@ func (c *DocumentDB) QueryUserDefinedFunctions(coll, query string) (udfs []UDF, 
 // Read all documents in a collection that satisfy a query
 func (c *DocumentDB) QueryDocuments(coll, query string, docs interface{}) (err error) {
 	data := struct {
-		Documents	interface{}	`json:"Documents,omitempty"`
-		Count		int		`json:"_count,omitempty"`
+		Documents interface{} `json:"Documents,omitempty"`
+		Count     int         `json:"_count,omitempty"`
 	}{Documents: docs}
 	if len(query) > 0 {
-		err = c.client.Query(coll + "docs/", query, &data)
+		err = c.client.Query(coll+"docs/", query, &data)
 	} else {
-		err = c.client.Read(coll + "docs/", &data)
+		err = c.client.Read(coll+"docs/", &data)
 	}
 	return
 }
@@ -187,7 +187,7 @@ func (c *DocumentDB) CreateDatabase(body interface{}) (db *Database, err error) 
 
 // Create collection
 func (c *DocumentDB) CreateCollection(db string, body interface{}) (coll *Collection, err error) {
-	err = c.client.Create(db + "colls/", body, &coll)
+	err = c.client.Create(db+"colls/", body, &coll)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (c *DocumentDB) CreateCollection(db string, body interface{}) (coll *Collec
 
 // Create stored procedure
 func (c *DocumentDB) CreateStoredProcedure(coll string, body interface{}) (sproc *Sproc, err error) {
-	err = c.client.Create(coll + "sprocs/", body, &sproc)
+	err = c.client.Create(coll+"sprocs/", body, &sproc)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func (c *DocumentDB) CreateStoredProcedure(coll string, body interface{}) (sproc
 
 // Create user defined function
 func (c *DocumentDB) CreateUserDefinedFunction(coll string, body interface{}) (udf *UDF, err error) {
-	err = c.client.Create(coll + "udfs/", body, &udf)
+	err = c.client.Create(coll+"udfs/", body, &udf)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,16 @@ func (c *DocumentDB) CreateDocument(coll string, doc interface{}) error {
 	if id.IsValid() && id.String() == "" {
 		id.SetString(uuid())
 	}
-	return c.client.Create(coll + "docs/", doc, &doc)
+	return c.client.Create(coll+"docs/", doc, &doc)
+}
+
+// Upsert document
+func (c *DocumentDB) UpsertDocument(coll string, doc interface{}) error {
+	id := reflect.ValueOf(doc).Elem().FieldByName("Id")
+	if id.IsValid() && id.String() == "" {
+		id.SetString(uuid())
+	}
+	return c.client.Upsert(coll+"docs/", doc, &doc)
 }
 
 // TODO: DRY, but the sdk want that[mm.. maybe just client.Delete(self_link)]

--- a/documentdb_test.go
+++ b/documentdb_test.go
@@ -2,8 +2,9 @@ package documentdb
 
 import (
 	"testing"
-	"github.com/stretchr/testify/mock"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type ClientStub struct {
@@ -21,6 +22,11 @@ func (c *ClientStub) Query(link, query string, ret interface{}) error {
 }
 
 func (c *ClientStub) Create(link string, body, ret interface{}) error {
+	c.Called(link, body)
+	return nil
+}
+
+func (c *ClientStub) Upsert(link string, body, ret interface{}) error {
 	c.Called(link, body)
 	return nil
 }
@@ -107,36 +113,36 @@ func TestReadCollections(t *testing.T) {
 	client := &ClientStub{}
 	c := &DocumentDB{client}
 	dbLink := "dblink/"
-	client.On("Read", dbLink + "colls/").Return(nil)
+	client.On("Read", dbLink+"colls/").Return(nil)
 	c.ReadCollections(dbLink)
-	client.AssertCalled(t, "Read", dbLink + "colls/")
+	client.AssertCalled(t, "Read", dbLink+"colls/")
 }
 
 func TestReadStoredProcedures(t *testing.T) {
 	client := &ClientStub{}
 	c := &DocumentDB{client}
 	collLink := "colllink/"
-	client.On("Read", collLink + "sprocs/").Return(nil)
+	client.On("Read", collLink+"sprocs/").Return(nil)
 	c.ReadStoredProcedures(collLink)
-	client.AssertCalled(t, "Read", collLink + "sprocs/")
+	client.AssertCalled(t, "Read", collLink+"sprocs/")
 }
 
 func TestReadUserDefinedFunctions(t *testing.T) {
 	client := &ClientStub{}
 	c := &DocumentDB{client}
 	collLink := "colllink/"
-	client.On("Read", collLink + "udfs/").Return(nil)
+	client.On("Read", collLink+"udfs/").Return(nil)
 	c.ReadUserDefinedFunctions(collLink)
-	client.AssertCalled(t, "Read", collLink + "udfs/")
+	client.AssertCalled(t, "Read", collLink+"udfs/")
 }
 
 func TestReadDocuments(t *testing.T) {
 	client := &ClientStub{}
 	c := &DocumentDB{client}
 	collLink := "colllink/"
-	client.On("Read", collLink + "docs/").Return(nil)
-	c.ReadDocuments(collLink, struct {}{})
-	client.AssertCalled(t, "Read", collLink + "docs/")
+	client.On("Read", collLink+"docs/").Return(nil)
+	c.ReadDocuments(collLink, struct{}{})
+	client.AssertCalled(t, "Read", collLink+"docs/")
 }
 
 func TestQueryDatabases(t *testing.T) {
@@ -175,9 +181,9 @@ func TestQueryDocuments(t *testing.T) {
 	client := &ClientStub{}
 	c := &DocumentDB{client}
 	collLink := "coll_self_link/"
-	client.On("Query", collLink + "docs/", "SELECT * FROM ROOT r").Return(nil)
-	c.QueryDocuments(collLink, "SELECT * FROM ROOT r", struct {}{})
-	client.AssertCalled(t, "Query", collLink + "docs/", "SELECT * FROM ROOT r")
+	client.On("Query", collLink+"docs/", "SELECT * FROM ROOT r").Return(nil)
+	c.QueryDocuments(collLink, "SELECT * FROM ROOT r", struct{}{})
+	client.AssertCalled(t, "Query", collLink+"docs/", "SELECT * FROM ROOT r")
 }
 
 func TestCreateDatabase(t *testing.T) {
@@ -220,6 +226,17 @@ func TestCreateDocument(t *testing.T) {
 	client.On("Create", "dbs/colls/docs/", &doc).Return(nil)
 	c.CreateDocument("dbs/colls/", &doc)
 	client.AssertCalled(t, "Create", "dbs/colls/docs/", &doc)
+	assert.NotEqual(t, doc.Id, "")
+}
+
+func TestUpsertDocument(t *testing.T) {
+	client := &ClientStub{}
+	c := &DocumentDB{client}
+	// TODO: test error situation, without id, etc...
+	var doc Document
+	client.On("Upsert", "dbs/colls/docs/", &doc).Return(nil)
+	c.UpsertDocument("dbs/colls/", &doc)
+	client.AssertCalled(t, "Upsert", "dbs/colls/docs/", &doc)
 	assert.NotEqual(t, doc.Id, "")
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,4 +24,16 @@ func TestDefaultHeaders(t *testing.T) {
 	assert.NotEqual(req.Header.Get(HEADER_AUTH), "")
 	assert.NotEqual(req.Header.Get(HEADER_XDATE), "")
 	assert.NotEqual(req.Header.Get(HEADER_VER), "")
+}
+
+func TestUpsertHeaders(t *testing.T) {
+	r, _ := http.NewRequest("POST", "link", &bytes.Buffer{})
+	req := ResourceRequest("/dbs/b5NCAA==/", r)
+	_ = req.UpsertHeaders("YXJpZWwNCg==")
+
+	assert := assert.New(t)
+	assert.NotEqual(req.Header.Get(HEADER_AUTH), "")
+	assert.NotEqual(req.Header.Get(HEADER_XDATE), "")
+	assert.NotEqual(req.Header.Get(HEADER_VER), "")
+	assert.Equal(req.Header.Get(HEADER_UPSERT), "true")
 }


### PR DESCRIPTION
CosmosDB SQL API has Upsert feature now. 
I add the future to enable it. 

However, it has several note for that.

#  1. Code of Upsert and Create can refactor. 

To enable Upsert, we just add x-ms-documentdb-is-upsert header to the Create REST call. However, current API is not aim for customize the header. If I refactor it, I need to change the other parts which already run successfully. Before doing that change, we should discuss how to refactor it in here. 

# 2.  Can't avoid Upsert Status error 

This code validate the match of the status code. However, In case of Upsert, we have no way to know the status code in advance. 

 https://github.com/a8m/documentdb-go/blob/master/client.go#L102-L106

It is not ideal, however, We can avoid to write the code like this. This should be also discuss in here. I'm not sure why the status matching is needed in here. 

```
		err := teamdb.Add(&v)
		errString := err.Error()
		if err != nil {
			// If you use upsert, the error happens with error sting ', '
			// which means status code validation error. Upsert can't predict which status code 200 or 201 in advance.
			if ", " != errString {
				fmt.Printf("upsert error! %d : '%s'", i, err.Error())
			}
		}
```

# 3 Partition Key is not supported

Partition Key is not supported (Should be the other pull request) It also require the new header and we need to pass the value to that header. maybe, refactor it to enable us to add custom header might be handy. 

FYI:  This is the sample of the upsert feature
https://github.com/TsuyoshiUshio/documentdbspike