### PR TITLE
Query documents using partition key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,62 @@
-## DocumentDB Go  [![Build status][travis-image]][travis-url]
-> Go driver for Microsoft Azure DocumentDB 
+## DocumentDB Go [![Build status][travis-image]][travis-url]
+
+> Go driver for Microsoft Azure DocumentDB
 
 ### Note
+
 This is a **WIP** project.  
 I'm doing it on my spare time and hope to stabilize it soon. if you want to contribute, feel free to take some task [here](https://github.com/a8m/documentdb-go/issues/3)
 
 ## Table of contents:
-- [Get Started](#get-started)
-- [Examples](#examples)
-- [Databases](#databases)
-  - [Get](#readdatabase)
-  - [Query](#querydatabases)
-  - [List](#readdatabases)
-  - [Create](#createdatabase)
-  - [Replace](#replacedatabase)
-  - [Delete](#deletedatabase)
-- [Collections](#collections)
-  - [Get](#readcollection)
-  - [Query](#querycollections)
-  - [List](#readcollection)
-  - [Create](#createcollection)
-  - [Delete](#deletecollection)
-- [Documents](#documents)
-  - [Get](#readdocument)
-  - [Query](#querydocuments)
-  - [List](#readdocuments)
-  - [Create](#createdocument)
-  - [Replace](#replacedocument)
-  - [Delete](#deletedocument)
-- [StoredProcedures](#storedprocedures)
-  - [Get](#readstoredprocedure)
-  - [Query](#querystoredprocedures)
-  - [List](#readstoredprocedures)
-  - [Create](#createstoredprocedure)
-  - [Replace](#replacestoredprocedure)
-  - [Delete](#deletestoredprocedure)
-  - [Execute](#executestoredprocedure)
-- [UserDefinedFunctions](#userdefinedfunctions)
-  - [Get](#readuserdefinedfunction)
-  - [Query](#queryuserdefinedfunctions)
-  - [List](#readuserdefinedfunctions)
-  - [Create](#createuserdefinedfunction)
-  - [Replace](#replaceuserdefinedfunction)
-  - [Delete](#deleteuserdefinedfunction)
+
+* [Get Started](#get-started)
+* [Examples](#examples)
+* [Databases](#databases)
+  * [Get](#readdatabase)
+  * [Query](#querydatabases)
+  * [List](#readdatabases)
+  * [Create](#createdatabase)
+  * [Replace](#replacedatabase)
+  * [Delete](#deletedatabase)
+* [Collections](#collections)
+  * [Get](#readcollection)
+  * [Query](#querycollections)
+  * [List](#readcollection)
+  * [Create](#createcollection)
+  * [Delete](#deletecollection)
+* [Documents](#documents)
+  * [Get](#readdocument)
+  * [Query](#querydocuments)
+  * [List](#readdocuments)
+  * [Create](#createdocument)
+  * [Replace](#replacedocument)
+  * [Delete](#deletedocument)
+* [StoredProcedures](#storedprocedures)
+  * [Get](#readstoredprocedure)
+  * [Query](#querystoredprocedures)
+  * [List](#readstoredprocedures)
+  * [Create](#createstoredprocedure)
+  * [Replace](#replacestoredprocedure)
+  * [Delete](#deletestoredprocedure)
+  * [Execute](#executestoredprocedure)
+* [UserDefinedFunctions](#userdefinedfunctions)
+  * [Get](#readuserdefinedfunction)
+  * [Query](#queryuserdefinedfunctions)
+  * [List](#readuserdefinedfunctions)
+  * [Create](#createuserdefinedfunction)
+  * [Replace](#replaceuserdefinedfunction)
+  * [Delete](#deleteuserdefinedfunction)
 
 ### Get Started
+
 #### Installation
+
 ```sh
 $ go get github.com/a8m/documentdb-go
 ```
+
 #### Add to your project
+
 ```go
 import (
 	"github.com/a8m/documentdb"
@@ -67,151 +74,176 @@ func main() {
 ```
 
 ### Databases
+
 #### ReadDatabase
+
 ```go
 func main() {
 	// ...
 	db, err := client.ReadDatabase("self_link")
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	fmt.Println(db.Self, db.Id)
 }
 ```
+
 #### QueryDatabases
+
 ```go
 func main() {
 	// ...
 	dbs, err := client.QueryDatabases("SELECT * FROM ROOT r")
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	for _, db := range dbs {
 		fmt.Println("DB Name:", db.Id)
 	}
 }
 ```
+
 #### ReadDatabases
+
 ```go
 func main() {
 	// ...
 	dbs, err := client.ReadDatabases()
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	for _, db := range dbs {
 		fmt.Println("DB Name:", db.Id)
 	}
 }
 ```
+
 #### CreateDatabase
+
 ```go
 func main() {
 	// ...
 	db, err := client.CreateDatabase(`{ "id": "test" }`)
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	fmt.Println(db)
-	
+
 	// or ...
 	var db documentdb.Database
 	db.Id = "test"
 	db, err = client.CreateDatabase(&db)
 }
 ```
+
 #### ReplaceDatabase
+
 ```go
 func main() {
 	// ...
 	db, err := client.ReplaceDatabase("self_link", `{ "id": "test" }`)
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	fmt.Println(db)
-	
+
 	// or ...
 	var db documentdb.Database
 	db, err = client.ReplaceDatabase("self_link", &db)
 }
 ```
+
 #### DeleteDatabase
+
 ```go
 func main() {
 	// ...
 	err := client.DeleteDatabase("self_link")
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 }
 ```
 
 ### Collections
+
 #### ReadCollection
+
 ```go
 func main() {
 	// ...
 	coll, err := client.ReadCollection("self_link")
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	fmt.Println(coll.Self, coll.Id)
 }
 ```
+
 #### QueryCollections
+
 ```go
 func main() {
 	// ...
 	colls, err := client.QueryCollections("db_self_link", "SELECT * FROM ROOT r")
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	for _, coll := range colls {
 		fmt.Println("Collection Name:", coll.Id)
 	}
 }
 ```
+
 #### ReadCollections
+
 ```go
 func main() {
 	// ...
 	colls, err := client.ReadCollections("db_self_link")
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	for _, coll := range colls {
 		fmt.Println("Collection Name:", coll.Id)
 	}
 }
 ```
+
 #### CreateCollection
+
 ```go
 func main() {
 	// ...
 	coll, err := client.CreateCollection("db_self_link", `{"id": "my_test"}`)
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	fmt.Println("Collection Name:", coll.Id)
-	
+
 	// or ...
 	var coll documentdb.Collection
 	coll.Id = "test"
 	coll, err = client.CreateCollection("db_self_link", &coll)
 }
 ```
+
 #### DeleteCollection
+
 ```go
 func main() {
 	// ...
 	err := client.DeleteCollection("self_link")
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 }
 ```
+
 ### Documents
+
 #### ReadDocument
+
 ```go
 type Document struct {
 	documentdb.Document
@@ -225,12 +257,14 @@ func main() {
 	var doc Document
 	err = client.ReadDocument("self_link", &doc)
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	fmt.Println("Document Name:", doc.Name)
 }
 ```
+
 #### QueryDocuments
+
 ```go
 type User struct {
 	documentdb.Document
@@ -244,14 +278,44 @@ func main() {
 	var users []User
 	err = client.QueryDocuments("coll_self_link", "SELECT * FROM ROOT r", &users)
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	for _, user := range users {
 		fmt.Print("Name:", user.Name, "Email:", user.Email)
 	}
 }
 ```
+
+#### QueryDocuments with partition key
+
+```go
+type User struct {
+	documentdb.Document
+	// Your external fields
+	Name    string `json:"name,omitempty"`
+	Email   string `json:"email,omitempty"`
+}
+
+func main() {
+	// ...
+	var users []User
+
+	partitionKey := func(reqOpts *documentdb.RequestOptions) {
+		reqOpts.PartitionKey = []string{"Your-Partition-Key"}
+	}
+
+	err = client.QueryDocumentsWithRequestOptions("coll_self_link", "SELECT * FROM ROOT r", &users, partitionKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, user := range users {
+		fmt.Print("Name:", user.Name, "Email:", user.Email)
+	}
+}
+```
+
 #### ReadDocuments
+
 ```go
 type User struct {
 	documentdb.Document
@@ -265,14 +329,16 @@ func main() {
 	var users []User
 	err = client.ReadDocuments("coll_self_link", &users)
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	for _, user := range users {
 		fmt.Print("Name:", user.Name, "Email:", user.Email)
 	}
 }
 ```
+
 #### CreateDocument
+
 ```go
 type User struct {
 	documentdb.Document
@@ -284,19 +350,21 @@ type User struct {
 func main() {
 	// ...
 	var user User
-	// Note: If the `id` is missing(or empty) in the payload it will generate 
+	// Note: If the `id` is missing(or empty) in the payload it will generate
 	// random document id(i.e: uuid4)
 	user.Id = "uuid"
 	user.Name = "Ariel"
 	user.Email = "ariel@test.com"
 	err := client.CreateDocument("coll_self_link", &doc)
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	fmt.Print("Name:", user.Name, "Email:", user.Email)
 }
 ```
+
 #### ReplaceDocument
+
 ```go
 type User struct {
 	documentdb.Document
@@ -311,23 +379,28 @@ func main() {
 	user.IsAdmin = false
 	err := client.ReplaceDocument("doc_self_link", &user)
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 	fmt.Print("Is Admin:", user.IsAdmin)
 }
 ```
+
 #### DeleteDocument
+
 ```go
 func main() {
 	// ...
 	err := client.DeleteDocument("doc_self_link")
 	if err != nil {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
 }
 ```
+
 ###
+
 #### ExecuteStoredProcedure
+
 ```go
 func main() {
 	// ...
@@ -341,11 +414,12 @@ func main() {
 ```
 
 ### Examples
-- [Go DocumentDB Example](https://github.com/a8m/go-documentdb-example) - A users CRUD application using Martini and DocumentDB
+
+* [Go DocumentDB Example](https://github.com/a8m/go-documentdb-example) - A users CRUD application using Martini and DocumentDB
 
 ### License
+
 MIT
 
 [travis-image]: https://img.shields.io/travis/a8m/documentdb-go.svg?style=flat-square
 [travis-url]: https://travis-ci.org/a8m/documentdb-go
-

--- a/documentdb.go
+++ b/documentdb.go
@@ -9,6 +9,10 @@ package documentdb
 
 import "reflect"
 
+type RequestOptions struct {
+	PartitionKey []string
+}
+
 type Config struct {
 	MasterKey string
 }
@@ -172,6 +176,29 @@ func (c *DocumentDB) QueryDocuments(coll, query string, docs interface{}) (err e
 		err = c.client.Query(coll+"docs/", query, &data)
 	} else {
 		err = c.client.Read(coll+"docs/", &data)
+	}
+	return
+}
+
+// Read all documents in a collection that satisfy a query and with request options
+func (c *DocumentDB) QueryDocumentsWithRequestOptions(coll, query string, docs interface{}, requestOptions ...func(*RequestOptions)) (err error) {
+	data := struct {
+		Documents interface{} `json:"Documents,omitempty"`
+		Count     int         `json:"_count,omitempty"`
+	}{Documents: docs}
+	// If there are request options
+	if len(requestOptions) > 0 {
+		if len(query) > 0 {
+			err = c.client.QueryWithRequestOptions(coll+"docs/", query, &data, requestOptions)
+		} else {
+			err = c.client.ReadWithRequestOptions(coll+"docs/", &data, requestOptions)
+		}
+	} else {
+		if len(query) > 0 {
+			err = c.client.Query(coll+"docs/", query, &data)
+		} else {
+			err = c.client.Read(coll+"docs/", &data)
+		}
 	}
 	return
 }

--- a/documentdb_test.go
+++ b/documentdb_test.go
@@ -17,8 +17,18 @@ func (c *ClientStub) Read(link string, ret interface{}) error {
 	return args.Error(0)
 }
 
+func (c *ClientStub) ReadWithRequestOptions(link string, ret interface{}, requestOptions []func(*RequestOptions)) error {
+	c.Called(link, requestOptions)
+	return nil
+}
+
 func (c *ClientStub) Query(link, query string, ret interface{}) error {
 	c.Called(link, query)
+	return nil
+}
+
+func (c *ClientStub) QueryWithRequestOptions(link, query string, ret interface{}, requestOptions []func(*RequestOptions)) error {
+	c.Called(link, query, requestOptions)
 	return nil
 }
 

--- a/request.go
+++ b/request.go
@@ -9,13 +9,14 @@ import (
 )
 
 const (
-	HEADER_XDATE    = "X-Ms-Date"
-	HEADER_AUTH     = "Authorization"
-	HEADER_VER      = "X-Ms-Version"
-	HEADER_CONTYPE  = "Content-Type"
-	HEADER_CONLEN   = "Content-Length"
-	HEADER_IS_QUERY = "X-Ms-Documentdb-Isquery"
-	HEADER_UPSERT   = "x-ms-documentdb-is-upsert"
+	HEADER_XDATE         = "X-Ms-Date"
+	HEADER_AUTH          = "Authorization"
+	HEADER_VER           = "X-Ms-Version"
+	HEADER_CONTYPE       = "Content-Type"
+	HEADER_CONLEN        = "Content-Length"
+	HEADER_IS_QUERY      = "X-Ms-Documentdb-Isquery"
+	HEADER_UPSERT        = "x-ms-documentdb-is-upsert"
+	HEADER_PARTITION_KEY = "x-ms-documentdb-partitionkey"
 )
 
 // Request Error
@@ -67,6 +68,31 @@ func (req *Request) UpsertHeaders(mkey string) (err error) {
 		return err
 	}
 	req.Header.Add(HEADER_UPSERT, "true")
+	return
+}
+
+// Add Request Options headers
+func (req *Request) RequestOptionsHeaders(requestOptions []func(*RequestOptions)) (err error) {
+
+	if requestOptions == nil {
+		return
+	}
+
+	reqOpts := RequestOptions{}
+
+	for _, requestOption := range requestOptions {
+		requestOption(&reqOpts)
+	}
+
+	if reqOpts.PartitionKey[0] != "" {
+		// The partition key header must be an array following the spec:
+		// https: //docs.microsoft.com/en-us/rest/api/cosmos-db/common-cosmosdb-rest-request-headers
+		// and must contain brackets
+		// example: x-ms-documentdb-partitionkey: [ "abc" ]
+
+		partitionKey := fmt.Sprintf("[\"%s\"]", reqOpts.PartitionKey[0])
+		req.Header[HEADER_PARTITION_KEY] = []string{partitionKey}
+	}
 	return
 }
 


### PR DESCRIPTION
For now the `RequestOptions` type only contains the `PartitionKey` property. This will allow to query documents given a specific `PartitionKey`.