### PR TITLE
Changed type for PartitionKey on RequestOptions to interface{}

### DIFF
--- a/documentdb.go
+++ b/documentdb.go
@@ -10,7 +10,7 @@ package documentdb
 import "reflect"
 
 type RequestOptions struct {
-	PartitionKey []string
+	PartitionKey interface{}
 }
 
 type Config struct {

--- a/documentdb.go
+++ b/documentdb.go
@@ -10,7 +10,7 @@ package documentdb
 import "reflect"
 
 type RequestOptions struct {
-	PartitionKey string
+	PartitionKey interface{}
 }
 
 type Config struct {

--- a/documentdb.go
+++ b/documentdb.go
@@ -10,7 +10,7 @@ package documentdb
 import "reflect"
 
 type RequestOptions struct {
-	PartitionKey interface{}
+	PartitionKey string
 }
 
 type Config struct {

--- a/request.go
+++ b/request.go
@@ -84,13 +84,13 @@ func (req *Request) RequestOptionsHeaders(requestOptions []func(*RequestOptions)
 		requestOption(&reqOpts)
 	}
 
-	if reqOpts.PartitionKey[0] != "" {
+	if reqOpts.PartitionKey != nil {
 		// The partition key header must be an array following the spec:
 		// https: //docs.microsoft.com/en-us/rest/api/cosmos-db/common-cosmosdb-rest-request-headers
 		// and must contain brackets
 		// example: x-ms-documentdb-partitionkey: [ "abc" ]
 
-		partitionKey := fmt.Sprintf("[\"%s\"]", reqOpts.PartitionKey[0])
+		partitionKey := fmt.Sprintf("[%v]", reqOpts.PartitionKey)
 		req.Header[HEADER_PARTITION_KEY] = []string{partitionKey}
 	}
 	return

--- a/request.go
+++ b/request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -84,11 +85,17 @@ func (req *Request) RequestOptionsHeaders(requestOptions []func(*RequestOptions)
 		requestOption(&reqOpts)
 	}
 
-	if reqOpts.PartitionKey != nil {
+	if reqOpts.PartitionKey != "" {
 		// The partition key header must be an array following the spec:
 		// https: //docs.microsoft.com/en-us/rest/api/cosmos-db/common-cosmosdb-rest-request-headers
 		// and must contain brackets
 		// example: x-ms-documentdb-partitionkey: [ "abc" ]
+		i, err := strconv.Atoi(reqOpts.PartitionKey)
+		if err == nil {
+			partitionKey := fmt.Sprintf("[%v]", i)
+			req.Header[HEADER_PARTITION_KEY] = []string{partitionKey}
+			return nil
+		}
 
 		partitionKey := fmt.Sprintf("[%v]", reqOpts.PartitionKey)
 		req.Header[HEADER_PARTITION_KEY] = []string{partitionKey}

--- a/request.go
+++ b/request.go
@@ -106,7 +106,7 @@ func (req *Request) RequestOptionsHeaders(requestOptions []func(*RequestOptions)
 			return err
 		}
 
-		req.Header.Set(HEADER_PARTITION_KEY, string(partitionKey))
+		req.Header[HEADER_PARTITION_KEY] = []string{string(partitionKey)}
 	}
 	return
 }

--- a/request.go
+++ b/request.go
@@ -91,8 +91,10 @@ func (req *Request) RequestOptionsHeaders(requestOptions []func(*RequestOptions)
 		// and must contain brackets
 		// example: x-ms-documentdb-partitionkey: [ "abc" ]
 
-		var partitionKey []byte
-		var err error
+		var (
+			partitionKey []byte
+			err          error
+		)
 		switch v := reqOpts.PartitionKey.(type) {
 		case json.Marshaler:
 			partitionKey, err = json.Marshal(v)
@@ -104,7 +106,7 @@ func (req *Request) RequestOptionsHeaders(requestOptions []func(*RequestOptions)
 			return err
 		}
 
-		req.Header[HEADER_PARTITION_KEY] = []string{string(partitionKey)}
+		req.Header.Set(HEADER_PARTITION_KEY, string(partitionKey))
 	}
 	return
 }

--- a/request_test.go
+++ b/request_test.go
@@ -58,7 +58,7 @@ func TestPartitionKeyMarshalJSON(t *testing.T) {
 	_ = req.RequestOptionsHeaders([]func(*RequestOptions){requestOptions})
 
 	assert := assert.New(t)
-	assert.Equal("{\"newProp\":\"test\"}", req.Header.Get(HEADER_PARTITION_KEY))
+	assert.Equal([]string{"{\"newProp\":\"test\"}"}, req.Header[HEADER_PARTITION_KEY])
 }
 
 func TestPartitionKeyAsInt(t *testing.T) {
@@ -70,7 +70,7 @@ func TestPartitionKeyAsInt(t *testing.T) {
 	_ = req.RequestOptionsHeaders([]func(*RequestOptions){requestOptions})
 
 	assert := assert.New(t)
-	assert.Equal("[1]", req.Header.Get(HEADER_PARTITION_KEY))
+	assert.Equal([]string{"[1]"}, req.Header[HEADER_PARTITION_KEY])
 }
 
 func TestPartitionKeyAsString(t *testing.T) {
@@ -82,5 +82,5 @@ func TestPartitionKeyAsString(t *testing.T) {
 	_ = req.RequestOptionsHeaders([]func(*RequestOptions){requestOptions})
 
 	assert := assert.New(t)
-	assert.Equal("[\"1\"]", req.Header.Get(HEADER_PARTITION_KEY))
+	assert.Equal([]string{"[\"1\"]"}, req.Header[HEADER_PARTITION_KEY])
 }

--- a/request_test.go
+++ b/request_test.go
@@ -58,7 +58,7 @@ func TestPartitionKeyMarshalJSON(t *testing.T) {
 	_ = req.RequestOptionsHeaders([]func(*RequestOptions){requestOptions})
 
 	assert := assert.New(t)
-	assert.Equal([]string{"{\"newProp\":\"test\"}"}, req.Header[HEADER_PARTITION_KEY])
+	assert.Equal("{\"newProp\":\"test\"}", req.Header.Get(HEADER_PARTITION_KEY))
 }
 
 func TestPartitionKeyAsInt(t *testing.T) {
@@ -70,7 +70,7 @@ func TestPartitionKeyAsInt(t *testing.T) {
 	_ = req.RequestOptionsHeaders([]func(*RequestOptions){requestOptions})
 
 	assert := assert.New(t)
-	assert.Equal([]string{"[1]"}, req.Header[HEADER_PARTITION_KEY])
+	assert.Equal("[1]", req.Header.Get(HEADER_PARTITION_KEY))
 }
 
 func TestPartitionKeyAsString(t *testing.T) {
@@ -82,5 +82,5 @@ func TestPartitionKeyAsString(t *testing.T) {
 	_ = req.RequestOptionsHeaders([]func(*RequestOptions){requestOptions})
 
 	assert := assert.New(t)
-	assert.Equal([]string{"[\"1\"]"}, req.Header[HEADER_PARTITION_KEY])
+	assert.Equal("[\"1\"]", req.Header.Get(HEADER_PARTITION_KEY))
 }

--- a/request_test.go
+++ b/request_test.go
@@ -2,11 +2,22 @@ package documentdb
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+type TestPartitionKey struct {
+	Prop string `json:"prop"`
+}
+
+func (t *TestPartitionKey) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		NewProp string `json:"newProp"`
+	}{NewProp: t.Prop})
+}
 
 func TestResourceRequest(t *testing.T) {
 	assert := assert.New(t)
@@ -36,4 +47,40 @@ func TestUpsertHeaders(t *testing.T) {
 	assert.NotEqual(req.Header.Get(HEADER_XDATE), "")
 	assert.NotEqual(req.Header.Get(HEADER_VER), "")
 	assert.Equal(req.Header.Get(HEADER_UPSERT), "true")
+}
+
+func TestPartitionKeyMarshalJSON(t *testing.T) {
+	r, _ := http.NewRequest("GET", "link", &bytes.Buffer{})
+	req := ResourceRequest("/dbs/b5NCAA==/", r)
+	requestOptions := func(reqOpts *RequestOptions) {
+		reqOpts.PartitionKey = &TestPartitionKey{"test"}
+	}
+	_ = req.RequestOptionsHeaders([]func(*RequestOptions){requestOptions})
+
+	assert := assert.New(t)
+	assert.Equal([]string{"{\"newProp\":\"test\"}"}, req.Header[HEADER_PARTITION_KEY])
+}
+
+func TestPartitionKeyAsInt(t *testing.T) {
+	r, _ := http.NewRequest("GET", "link", &bytes.Buffer{})
+	req := ResourceRequest("/dbs/b5NCAA==/", r)
+	requestOptions := func(reqOpts *RequestOptions) {
+		reqOpts.PartitionKey = 1
+	}
+	_ = req.RequestOptionsHeaders([]func(*RequestOptions){requestOptions})
+
+	assert := assert.New(t)
+	assert.Equal([]string{"[1]"}, req.Header[HEADER_PARTITION_KEY])
+}
+
+func TestPartitionKeyAsString(t *testing.T) {
+	r, _ := http.NewRequest("GET", "link", &bytes.Buffer{})
+	req := ResourceRequest("/dbs/b5NCAA==/", r)
+	requestOptions := func(reqOpts *RequestOptions) {
+		reqOpts.PartitionKey = "1"
+	}
+	_ = req.RequestOptionsHeaders([]func(*RequestOptions){requestOptions})
+
+	assert := assert.New(t)
+	assert.Equal([]string{"[\"1\"]"}, req.Header[HEADER_PARTITION_KEY])
 }


### PR DESCRIPTION
The partition key only allowed for string, but this did not work if the partitioned collection was patitioned on an int. In order to accommodate for different types of partition keys, I've changed the []string to an interface{}. Since CosmosDb only allows for one partition key per request, I've made it so you don't have to initialize an array, but a value, simplifying the code. Now works for int as well as string.